### PR TITLE
Add stimulus classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ignore = [
     "D105", # Missing docstring in magic method
     "D107", # Missing docstring in `__init__`
 ]
-pydocstyle.convention = "google"
+pydocstyle.convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can ignore a few extra rules

--- a/src/popylar_prf/stimulus.py
+++ b/src/popylar_prf/stimulus.py
@@ -1,0 +1,160 @@
+"""Containers for stimuli and stimulus grids."""
+
+from collections.abc import Sequence
+import numpy as np
+
+
+class GridDesignShapeError(Exception):
+    """
+    Exception raised when the shapes of the stimulus design and grid do not match.
+
+    Parameters
+    ----------
+    design_shape : tuple of int
+        Shape of the design array.
+    grid_shape : tuple of int
+        Shape of the grid array.
+    """
+
+    def __init__(self, design_shape: tuple[int], grid_shape: tuple[int]):
+        super().__init__(f"Shapes of 'design' {design_shape} and 'grid' {grid_shape} do not match")
+
+
+class GridDimensionsError(Exception):
+    """
+    Exception raised when number of grid dimensions except for the last does not match last grid dimension size.
+
+    Parameters
+    ----------
+    grid_shape: tuple of int
+        Shape of the grid array.
+
+    """
+
+    def __init__(self, grid_shape: tuple[int]) -> None:
+        num_grid_axes = len(grid_shape[:-1])
+        super().__init__(
+            f"The number of dimensions in 'grid' {num_grid_axes} does not match its last dimension {grid_shape[-1]}",
+        )
+
+
+class DimensionLabelsError(Exception):
+    """
+    Exception raised when the number of dimensions does not match the grid's last dimension.
+
+    Parameters
+    ----------
+    dimensions_len : int
+        Length of the dimensions sequence.
+    grid_dim : int
+        Size of the last dimension of the grid.
+    """
+
+    def __init__(self, dimensions_len: int, grid_dim: int):
+        super().__init__(f"Length of 'dimensions' {dimensions_len} does not match last dimension of 'grid' {grid_dim}")
+
+
+class Stimulus:
+    """
+    Container for a stimulus design and its associated grid.
+
+    Parameters
+    ----------
+    design : numpy.ndarray
+        The stimulus design array containing the stimulus value in one or more dimensions over different time frames.
+        The first axis is assumed to be time frames. Additional axes represent design dimensions.
+    grid : numpy.ndarray
+        The coordinate system of the stimulus array. The last axis is the number of design dimensions
+        excluding the time frame dimension. The shape excluding the last axis must match the shape
+        of the design excluding the first axis.
+    dimension_labels : Sequence[str] or None, optional
+        Names of the grid dimensions (e.g., `["y", "x"]`). If given, the number of labels must match the last grid axis.
+
+    Raises
+    ------
+    GridDesignShapeError
+        If the design and grid dimensions do not match.
+    GridDimensionsError
+        If the number of dimensions of the grid except the last does not match the size of the last grid dimension.
+    DimensionLabelsError
+        If the number of dimensions does not match the grid's last dimension.
+
+    Notes
+    -----
+    The shapes of the design and grid must match according to `design.shape[1:] == grid.shape[:-1]`.
+    That is, all design dimensions but the first must have the same size as the grid
+    dimensions excluding the last grid dimension.
+
+    Examples
+    --------
+    Create a stimulus on a 2D grid.
+    >>> import numpy as np
+    >>> from popylar_prf import Stimulus
+    >>> num_frames, width, height = 10, 16, 16
+    >>> design = np.ones((num_frames, width, height))
+    >>> pixel_size = 0.05
+    >>> x = (np.arange(width) - (width - 1) / 2) * pixel_size
+    >>> y = (np.arange(height) - (height - 1) / 2) * pixel_size
+    >>> xv, yv = np.meshgrid(x, y)
+    >>> grid = np.stack((xv, yv), axis=-1)  # shape (height, width, 2)
+    >>> grid = np.stack((xv, yv), axis=-1)  # shape (height, width, 2)
+    >>> # The coordinates of the bottom-left corner:
+    >>> grid[0, 0, :]
+    array([-0.375, -0.375])
+    >>> # The coordinates of the top-right corner:
+    >>> grid[15, 15, :]
+    array([0.375, 0.375])
+    >>> Stimulus(design=design, grid=grid, dimension_labels=["y", "x"])
+    Stimulus(design=array[10, 16, 16], grid=array[16, 16, 2], dimension_labels=['y', 'x'])
+
+    """
+
+    __hash__ = None  # We don't want the object to be hashable because it's mutable
+
+    def __init__(self, design: np.ndarray, grid: np.ndarray, dimension_labels: Sequence[str] | None = None):
+        self.design = design
+        self.grid = grid
+        self.dimension_labels = dimension_labels
+
+        self._check_grid_design_shape()
+        self._check_grid_dimensions()
+        self._check_dimension_labels()
+
+    def _check_grid_design_shape(self) -> None:
+        if not self.design.shape[1:] == self.grid.shape[:-1]:
+            raise GridDesignShapeError(self.design.shape, self.grid.shape)
+
+    def _check_grid_dimensions(self) -> None:
+        if not len(self.grid.shape[:-1]) == self.grid.shape[-1]:
+            raise GridDimensionsError(self.grid.shape)
+
+    def _check_dimension_labels(self) -> None:
+        if self.dimension_labels is not None and not self.grid.shape[-1] == len(self.dimension_labels):
+            raise DimensionLabelsError(len(self.dimension_labels), self.grid.shape[-1])
+
+    def __repr__(self) -> str:
+        return f"""{self.__class__.__name__}(
+            design={np.array_repr(self.design)},
+            grid={np.array_repr(self.grid)},
+            dimension_labels={self.dimension_labels}
+        )"""
+
+    def __str__(self) -> str:
+        design_shape_str = ", ".join([str(s) for s in self.design.shape])
+        grid_shape_str = ", ".join([str(s) for s in self.grid.shape])
+
+        return f"{self.__class__.__name__}(design=array[{design_shape_str}], grid=array[{grid_shape_str}], dimension_labels={self.dimension_labels})"  # noqa: E501
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Stimulus):
+            msg = "Stimulus objects can only be compared against other Stimulus objects"
+            raise TypeError(msg)
+
+        if self.design.shape != other.design.shape or self.grid.shape != other.grid.shape:
+            return False
+
+        design_equal = np.all(self.design == other.design)
+        grid_equal = np.all(self.grid == other.grid)
+        dimensions_labels_equal = self.dimension_labels == other.dimension_labels
+
+        return bool(design_equal and grid_equal and dimensions_labels_equal)

--- a/tests/test_stimulus.py
+++ b/tests/test_stimulus.py
@@ -135,3 +135,35 @@ def test_rectangular_grid(dimensions: str, axis: str):
     )
 
     assert isinstance(stimulus, Stimulus)
+
+
+@pytest.mark.parametrize("direction", ["horizontal", "vertical"])
+def test_create_2d_bar_stimulus(direction: str):
+    """Check that a valid 2D bar stimulus can be created."""
+    stimulus = Stimulus.create_2d_bar_stimulus(
+        num_frames=10,
+        width=5,
+        height=4,
+        direction=direction,
+    )
+
+    assert isinstance(stimulus, Stimulus)
+    # First and last frame should be empty
+    assert np.all(stimulus.design[0] == 0.0)
+    assert np.all(stimulus.design[-1] == 0.0)
+
+    # Design should have range 0-1
+    assert np.min(stimulus.design) == 0.0
+    assert np.max(stimulus.design) == 1.0
+
+    match direction:
+        case "horizontal":
+            # For horizontal bars, each row (height axis) should have the same value within a frame
+            # Each row in the frame should be constant
+            rows_equal = np.all(stimulus.design == stimulus.design[:, [0], :])  # (10,5,4) == (10,1,4)
+            assert np.all(rows_equal)
+        case "vertical":
+            # For vertical bars, each column (width axis) should have the same value within a frame
+            # All values in each column should be equal for all frames
+            cols_equal = np.all(stimulus.design == stimulus.design[:, :, [0]])
+            assert np.all(cols_equal)

--- a/tests/test_stimulus.py
+++ b/tests/test_stimulus.py
@@ -1,0 +1,137 @@
+"""Test stimulus classes."""
+
+import numpy as np
+import pytest
+
+# Needs to be imported to recreate stimulus from repr
+from numpy import array  # noqa: F401
+from popylar_prf.stimulus import DimensionLabelsError
+from popylar_prf.stimulus import GridDesignShapeError
+from popylar_prf.stimulus import GridDimensionsError
+from popylar_prf.stimulus import Stimulus
+
+
+def test_grid_design_shape_error():
+    """Check that shape mismatches are detected correctly by Stimulus."""
+    with pytest.raises(GridDesignShapeError):
+        _ = Stimulus(
+            design=np.zeros((1, 2)),
+            grid=np.zeros((1, 1)),
+        )
+
+
+def test_grid_dimension_error():
+    """Check that shape mismatches are detected correctly by Stimulus."""
+    with pytest.raises(GridDimensionsError):
+        _ = Stimulus(
+            design=np.zeros((1, 1, 2)),
+            grid=np.zeros((1, 2, 1)),
+        )
+
+
+def test_dimension_labels_error():
+    """Check that dimension mismatches are detected correctly by Stimulus."""
+    with pytest.raises(DimensionLabelsError):
+        _ = Stimulus(
+            design=np.zeros((1, 2)),
+            grid=np.zeros((2, 1)),
+            dimension_labels=["x", "y"],
+        )
+
+
+@pytest.fixture
+def stimulus():
+    """Stimulus object."""
+    return Stimulus(
+        design=np.zeros((1, 2, 1)),
+        grid=np.zeros((2, 1, 2)),
+        dimension_labels=["x", "y"],
+    )
+
+
+def test_repr(stimulus: Stimulus):
+    """Test machine-readable string representation of Stimulus."""
+    stimulus_2 = eval(repr(stimulus))  # noqa: S307
+
+    assert stimulus == stimulus_2
+
+
+def test_str(stimulus: Stimulus):
+    """Test human-readable string representation of Stimulus."""
+    assert str(stimulus) == "Stimulus(design=array[1, 2, 1], grid=array[2, 1, 2], dimension_labels=['x', 'y'])"
+
+
+def test_eq(stimulus: Stimulus):
+    """Test equality of two Stimulus objects."""
+    stimulus_2 = Stimulus(
+        design=np.zeros((1, 2, 1)),
+        grid=np.zeros((2, 1, 2)),
+        dimension_labels=["x", "y"],
+    )
+
+    assert stimulus == stimulus_2
+
+    with pytest.raises(TypeError):
+        _ = stimulus == np.zeros((0, 0, 0))
+
+
+def test_ne(stimulus: Stimulus):
+    """Test inequality of two Stimulus objects."""
+    stimulus_3 = Stimulus(
+        design=np.zeros((1, 2, 2)),
+        grid=np.zeros((2, 2, 2)),
+        dimension_labels=["x", "y"],
+    )
+
+    assert stimulus != stimulus_3
+
+
+def test_hash(stimulus: Stimulus):
+    """Test hash of two Stimulus objects."""
+    with pytest.raises(TypeError):
+        _ = hash(stimulus)
+
+
+@pytest.mark.parametrize(
+    ("dimensions", "axis"),
+    [("1D", "width"), ("2D", "width"), ("2D", "height"), ("3D", "depth")],
+)
+def test_rectangular_grid(dimensions: str, axis: str):
+    """Check that rectangular grids can be created."""
+    width = 10
+    height = 20
+    depth = 10
+
+    scale = 2
+
+    match axis:
+        case "width":
+            width *= scale
+        case "height":
+            height *= scale
+        case "depth":
+            depth *= scale
+
+    num_frames = 10
+
+    # 1D shape
+    design_shape = (num_frames, width)
+    grid_shape = (width, 1)
+
+    match dimensions:
+        case "2D":
+            design_shape = (num_frames, width, height)
+            grid_shape = (width, height, 2)
+        case "3D":
+            design_shape = (num_frames, width, height, depth)
+            grid_shape = (width, height, depth, 3)
+
+    design = np.zeros(design_shape)
+    grid = np.zeros(grid_shape)
+
+    stimulus = Stimulus(
+        design=design,
+        grid=grid,
+    )
+
+    assert isinstance(stimulus, Stimulus)


### PR DESCRIPTION
Closes #9 
Closes #11 

Adds a basic stimulus class `Stimulus`.

Adds a constructor method to create a 2D bar stimulus that either moves horizontally or vertically across the screen. This will be helpful to create realistic examples and test cases.