### PR TITLE
Add Gaussian pRF models

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,11 @@ jobs:
       - name: Upgrade pip and install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install .[dev,publishing]
+          python -m pip install .[dev,publishing,tensorflow]
       - name: Run unit tests
         run: python -m pytest -v
+        env:
+          KERAS_BACKEND: tensorflow
       - name: Verify that we can build the package
         run: python -m build
   lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,3 +89,23 @@ jobs:
         run: python -m pytest -v
         env:
           KERAS_BACKEND: ${{ matrix.backend }}
+  mypy:
+    name: Check types with mypy
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Python info
+        shell: bash -e {0}
+        run: |
+          which python
+          python --version
+      - name: Upgrade pip and install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install .[dev,publishing,tensorflow,torch,jax]
+      - name: Run mypy on package
+        run: mypy src/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,29 @@ jobs:
         run: |
           ruff check
           ruff format --check
+  backend:
+    name: Run tests for backend ${{ matrix.backend }}
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: true
+      matrix:
+        backend: ['tensorflow', 'torch', 'jax']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Python info
+        shell: bash -e {0}
+        run: |
+          which python
+          python --version
+      - name: Upgrade pip and install dependencies with backend ${{ matrix.backend }}
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install .[dev,publishing,${{ matrix.backend }}]
+      - name: Run unit tests
+        run: python -m pytest -v
+        env:
+          KERAS_BACKEND: ${{ matrix.backend }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["keras", "numpy", "pandas"]
+dependencies = ["keras", "numpy", "pandas", "scipy"]
 description = "A modern Python implementation for population receptive field modelling."
 keywords = [""]
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dev = [
     "sphinx",
     "sphinx-autoapi",
     "furo",
+    "mypy",
+    "types-tensorflow",
+    "pandas-stubs",
 ]
 publishing = [
     "build",
@@ -132,3 +135,7 @@ filename = "src/popylar_prf/__init__.py"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
+
+[[tool.mypy.overrides]]
+module = ["keras.*"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ publishing = [
     "twine",
     "wheel",
 ]
+torch = ["torch"]
+jax = ["jax"]
+tensorflow = ["tensorflow"]
 
 [project.urls]
 Repository = "https://github.com/popylar-org/popylar_prf"

--- a/src/popylar_prf/__init__.py
+++ b/src/popylar_prf/__init__.py
@@ -3,6 +3,7 @@
 import logging
 from popylar_prf.stimulus import Stimulus
 from popylar_prf.typing import Tensor
+from popylar_prf.utils import convert_parameters_to_tensor
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -12,4 +13,5 @@ __version__ = "0.0.1"
 __all__ = [
     "Stimulus",
     "Tensor",
+    "convert_parameters_to_tensor",
 ]

--- a/src/popylar_prf/__init__.py
+++ b/src/popylar_prf/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 from popylar_prf.stimulus import Stimulus
+from popylar_prf.typing import Tensor
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -10,4 +11,5 @@ __version__ = "0.0.1"
 
 __all__ = [
     "Stimulus",
+    "Tensor",
 ]

--- a/src/popylar_prf/models/__init__.py
+++ b/src/popylar_prf/models/__init__.py
@@ -1,0 +1,9 @@
+"""Population receptive field models."""
+
+from .base import BaseModel
+from .base import ResponseModel
+
+__all__ = [
+    "BaseModel",
+    "ResponseModel",
+]

--- a/src/popylar_prf/models/base.py
+++ b/src/popylar_prf/models/base.py
@@ -1,0 +1,115 @@
+"""Model base classes."""
+
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import Sequence
+import pandas as pd
+from popylar_prf.stimulus import Stimulus
+from popylar_prf.typing import Tensor
+
+_MIN_PARAMETER_DIM = 2
+
+
+class ParameterBatchDimensionError(Exception):
+    """
+    Exception raised when model parameters have different sizes in the batch (first) dimension.
+
+    Parameters
+    ----------
+    parameter_names: Sequence[str]
+        Names of parameters that have different sizes in batch dimension.
+    parameter_shapes: Sequence[tuple of int]
+        Shapes of parameters that have different sizes in batch dimension.
+
+    """
+
+    def __init__(self, parameter_names: Sequence[str], parameter_shapes: Sequence[tuple[int, ...]]):
+        names = ", ".join(parameter_names)
+        shapes = ", ".join([str(s[0]) for s in parameter_shapes])
+
+        super().__init__(f"Parameters {names} have different sizes in batch (first) dimension: {shapes}")
+
+
+class ParameterShapeError(Exception):
+    """
+    Exception raised when a model parameter has less than two dimensions.
+
+    Parameters
+    ----------
+    parameter_name: str
+        Parameter name.
+    parameter_shape: tuple of int
+        Parameter shape.
+
+    """
+
+    def __init__(self, parameter_name: str, parameter_shape: tuple[int, ...]):
+        super().__init__(
+            f"Parameter {parameter_name} must have at least two dimensions but has shape {parameter_shape}",
+        )
+
+
+class BaseModel(ABC):
+    """
+    Abstract base class for models.
+
+    Cannot be instantiated on its own.
+    Can only be used as a parent class to create custom model classes.
+    Subclasses must override the abstract `parameter_names` property.
+
+    Attributes
+    ----------
+    parameter_names
+
+    Examples
+    --------
+    Create a custom model class that inherits from the base class:
+
+    >>> class CustomModel(BaseModel):
+    >>>     @property
+    >>>     def parameter_names(self):
+    >>>         return ["a", "b"]
+    >>> model = CustomModel()
+    >>> print(model.parameter_names)
+    ["a", "b"]
+
+    """
+
+    @property
+    @abstractmethod
+    def parameter_names(self) -> list:
+        """A list with names of parameters that are used by the model."""
+
+
+class ResponseModel(BaseModel):
+    """
+    Abstract base class for population receptive field response models.
+
+    Cannot be instantiated on its own.
+    Can only be used as a parent class to create custom population receptive field models.
+    Subclasses must override the abstract `__call__` method.
+
+    #TODO: Link to Example on how to create custom response models.
+
+    """
+
+    @abstractmethod
+    def __call__(self, stimulus: Stimulus, parameters: pd.DataFrame) -> Tensor:
+        """
+        Predict the model response for a stimulus.
+
+        Parameters
+        ----------
+        stimulus : Stimulus
+            Stimulus object.
+        parameters : pandas.DataFrame
+            Dataframe with columns containing different model parameters and rows containing parameter values
+            for different voxels.
+
+        Returns
+        -------
+        Tensor
+            Model predictions of shape `(num_voxels, ...)`. The number of voxels is the number of rows in
+            `parameters`. The number and size of other axes depends on the stimulus.
+
+        """

--- a/src/popylar_prf/models/gaussian.py
+++ b/src/popylar_prf/models/gaussian.py
@@ -1,0 +1,146 @@
+"""Gaussian population receptive field response models."""
+
+from keras import ops
+from popylar_prf.stimulus import GridDimensionsError
+from popylar_prf.typing import Tensor
+from .base import _MIN_PARAMETER_DIM
+from .base import ParameterBatchDimensionError
+from .base import ParameterShapeError
+
+
+class GridMuDimensionsError(Exception):
+    """
+    Exception raised when the dimensions of the stimulus grid and the Gaussian mu parameter do not match.
+
+    For a stimulus grid with shape (..., m), the shape of the Gaussian mu parameter must be (num_batches, m).
+
+    Parameters
+    ----------
+    grid_shape : tuple of int
+        Shape of the stimulus grid.
+    mu_shape : tuple of int
+        Shape of the Gaussian mu parameter.
+
+    """
+
+    def __init__(self, grid_shape: tuple[int, ...], mu_shape: tuple[int, ...]):
+        super().__init__(f"For 'grid' {grid_shape} and 'mu' {mu_shape} do not match")
+
+
+def _check_gaussian_args(grid: Tensor, mu: Tensor, sigma: Tensor) -> None:
+    if not len(grid.shape[:-1]) == grid.shape[-1]:
+        raise GridDimensionsError(grid.shape)
+
+    if len(mu.shape) < _MIN_PARAMETER_DIM:
+        raise ParameterShapeError(
+            parameter_name="mu",
+            parameter_shape=mu.shape,
+        )
+
+    if len(sigma.shape) < _MIN_PARAMETER_DIM:
+        raise ParameterShapeError(
+            parameter_name="sigma",
+            parameter_shape=sigma.shape,
+        )
+
+    if grid.shape[-1] != mu.shape[-1]:
+        raise GridMuDimensionsError(grid.shape, mu.shape)
+
+    if mu.shape[0] != sigma.shape[0]:
+        raise ParameterBatchDimensionError(
+            parameter_names=("mu", "sigma"),
+            parameter_shapes=(mu.shape, sigma.shape),
+        )
+
+
+def _expand_gaussian_args(grid: Tensor, mu: Tensor, sigma: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+    # Expand mu to same shape as grid: (num_batches, ..., grid.shape[-1])
+    mu_expand = tuple(range(1, grid.shape[-1] + 1))
+    # Expand sigma to same shape as grid but omit last grid dimension
+    sigma_expand = mu_expand[:-1]
+
+    mu = ops.expand_dims(mu, axis=mu_expand)
+    sigma = ops.expand_dims(sigma, axis=sigma_expand)
+    # Add new first dimension to grid corresponding to num_batches
+    grid = ops.expand_dims(grid, axis=0)
+
+    return grid, mu, sigma
+
+
+def predict_gaussian_response(grid: Tensor, mu: Tensor, sigma: Tensor) -> Tensor:
+    """
+    Predict a isotropic Gaussian population receptive field response.
+
+    The dimensionality of the Gaussian depends on the number of dimensions of `grid` and `mu`. All dimensions have
+    the same size `sigma`.
+
+    Parameters
+    ----------
+    grid : Tensor
+        Stimulus grid for which to make predictions.
+    mu : Tensor
+        Centroid of the population receptive field. Must have at least two dimensions.
+        The first dimension corresponds to the number of batches.
+        The second dimension corresponds to the number of grid dimensions and must match the size of the
+        last `grid` dimension.
+    sigma : Tensor
+        Size of the population receptive field. Must have at least two dimensions.
+        The first dimension corresponds to the number of batches,
+        and its size must match the size of the first `mu` dimension.
+        The second dimension must have size one (because all Gaussian dimensions have the same size).
+
+    Returns
+    -------
+    Tensor
+        The predicted Gaussian population receptive field response with shape (num_batches, ...)
+        where `...` corresponds to the dimensions of the Gaussian.
+
+    Raises
+    ------
+    GridDimensionsError
+        If the grid has mismatching dimensions.
+    GridMuDimensionsError
+        If the grid and mu dimensions do not match.
+    ParameterBatchDimensionError
+        If `mu` and `sigma` have batch (first) dimensions with different sizes.
+    ParameterShapeError
+        If `mu` or `sigma` have less than two dimensions.
+
+    Examples
+    --------
+    Predict a 2D Gaussian response:
+
+    >>> import numpy as np
+    >>> # Define a 2D grid
+    >>> num_x, num_y = 10, 10
+    >>> x = np.linspace(-3, 3, num_x)
+    >>> y = np.linspace(-4, 4, num_y)
+    >>> xv, yv = np.meshgrid(x, y)
+    >>> grid = np.stack((xv, yv), axis=-1)  # shape (10, 10, 2)
+    >>> # Define 2D centroids of Gaussian for 3 batches
+    >>> mu = np.array([ # shape (3, 2), first column y, second column x
+    >>>     [0.0, 1.0],
+    >>>     [1.0, 0.0],
+    >>>     [0.0, 0.0],
+    >>> ])
+    >>> # Define size of Gaussian for 3 batches
+    >>> sigma = np.array([[1.0], [1.5], [2.0]]) # shape (3, 1)
+    >>> resp = predict_gaussian_response(grid, mu, sigma)
+    >>> print(resp.shape) # (num_batches, num_y, num_x)
+    (3, 10, 10)
+
+    """
+    grid = ops.convert_to_tensor(grid)
+    mu = ops.convert_to_tensor(mu)
+    sigma = ops.convert_to_tensor(sigma)
+
+    _check_gaussian_args(grid, mu, sigma)
+
+    # Expand axes to enable keras.ops autocasting
+    grid, mu, sigma = _expand_gaussian_args(grid, mu, sigma)
+
+    # Gaussian response
+    resp = ops.sum(ops.square(grid - mu), axis=-1)
+    resp /= 2 * ops.square(sigma)
+
+    return ops.exp(-resp)

--- a/src/popylar_prf/stimulus.py
+++ b/src/popylar_prf/stimulus.py
@@ -16,7 +16,7 @@ class GridDesignShapeError(Exception):
         Shape of the grid array.
     """
 
-    def __init__(self, design_shape: tuple[int], grid_shape: tuple[int]):
+    def __init__(self, design_shape: tuple[int], grid_shape: tuple[int, ...]):
         super().__init__(f"Shapes of 'design' {design_shape} and 'grid' {grid_shape} do not match")
 
 
@@ -31,7 +31,7 @@ class GridDimensionsError(Exception):
 
     """
 
-    def __init__(self, grid_shape: tuple[int]) -> None:
+    def __init__(self, grid_shape: tuple[int, ...]) -> None:
         num_grid_axes = len(grid_shape[:-1])
         super().__init__(
             f"The number of dimensions in 'grid' {num_grid_axes} does not match its last dimension {grid_shape[-1]}",
@@ -111,7 +111,8 @@ class Stimulus:
 
     """
 
-    __hash__ = None  # We don't want the object to be hashable because it's mutable
+    # We don't want the object to be hashable because it's mutable
+    __hash__ = None  # type: ignore[assignment]
 
     def __init__(self, design: np.ndarray, grid: np.ndarray, dimension_labels: Sequence[str] | None = None):
         self.design = design

--- a/src/popylar_prf/typing.py
+++ b/src/popylar_prf/typing.py
@@ -1,0 +1,18 @@
+"""Multi-backend variable types."""
+
+from typing import TypeAlias
+import keras
+
+match keras.backend.backend():
+    case "jax":
+        from jax import Array as BackendTensor  # type: ignore[assignment]
+    case "tensorflow":
+        from tensorflow import Tensor as BackendTensor  # type: ignore[assignment]
+    case "torch":
+        from torch import Tensor as BackendTensor  # type: ignore[assignment]
+    case other:
+        msg = f"Backend '{other}' is not supported."
+        raise ValueError(msg)
+
+Tensor: TypeAlias = BackendTensor
+"""Backend-specific tensor type."""

--- a/src/popylar_prf/utils.py
+++ b/src/popylar_prf/utils.py
@@ -1,0 +1,45 @@
+"""Utility functions."""
+
+import pandas as pd
+from keras import ops
+from .typing import Tensor
+
+
+def convert_parameters_to_tensor(parameters: pd.DataFrame) -> Tensor:
+    """Convert model parameters in a dataframe into a tensor.
+
+    Parameters
+    ----------
+    parameters : pandas.DataFrame
+        Dataframe with columns containing different model parameters and rows containing
+        parameter values for different voxels.
+
+    Returns
+    -------
+    Tensor
+        Tensor with the first axis corresponding to voxels and the second axis corresponding to different parameters.
+
+    Examples
+    --------
+    Single parameters:
+
+    >>> import pandas as pd
+    >>> params = pd.DataFrame({
+    >>>     "param_1": [0.0, 1.0, 2.0],
+    >>> })
+    >>> x = convert_parameters_to_tensor(params)
+    >>> print(x.shape)
+    (3, 1)
+
+    Multiple parameters:
+
+    >>> params = pd.DataFrame({
+    >>>     "param_1": [0.0, 1.0, 2.0],
+    >>>     "param_2": [0.0, -1.0, -2.0],
+    >>> })
+    >>> x = covert_parameters_to_tensor(params)
+    >>> print(x.shape)
+    (3, 2)
+
+    """
+    return ops.convert_to_tensor(parameters)

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,0 +1,50 @@
+"""Test model base classes."""
+
+import pytest
+from popylar_prf.models.base import BaseModel
+from popylar_prf.models.base import ParameterBatchDimensionError
+from popylar_prf.models.base import ParameterShapeError
+from popylar_prf.models.base import ResponseModel
+
+
+def test_parameter_shape_error():
+    """Test that ParameterShapeError shows correct parameter name and shape in error message."""
+    param_name = "param_1"
+    param_shape = 1
+
+    with pytest.raises(ParameterShapeError) as excinfo:
+        raise ParameterShapeError(param_name, param_shape)
+
+    assert param_name in str(excinfo.value)
+    assert str(param_shape) in str(excinfo.value)
+
+
+def test_parameter_batch_dimension_error():
+    """Test that ParameterBatchDimensionError shows correct parameter names and shapes in error message."""
+    param_names = ("param_1", "param_2")
+    param_shapes = ((2, 1), (1, 1))
+
+    with pytest.raises(ParameterBatchDimensionError) as excinfo:
+        raise ParameterBatchDimensionError(param_names, param_shapes)
+
+    for param_name, param_shape in zip(param_names, param_shapes, strict=False):
+        assert param_name in str(excinfo.value)
+        assert str(param_shape[0]) in str(excinfo.value)
+
+
+class TestBaseModel:
+    """Tests for BaseModel class."""
+
+    model_class = BaseModel
+
+    def test_abstract_fail(self):
+        """Test that model instantiation fails."""
+        with pytest.raises(TypeError):
+            _ = self.model_class()
+
+
+# Inherit all checks from TestBaseModel
+class TestResponseModel(TestBaseModel):
+    """Tests for ResponseModel class."""
+
+    model_class = ResponseModel

--- a/tests/models/test_gaussian.py
+++ b/tests/models/test_gaussian.py
@@ -1,0 +1,165 @@
+"""Test Gaussian model classes."""
+
+import numpy as np
+import pytest
+from popylar_prf.models.base import ParameterBatchDimensionError
+from popylar_prf.models.base import ParameterShapeError
+from popylar_prf.models.gaussian import GridMuDimensionsError
+from popylar_prf.models.gaussian import _check_gaussian_args
+from popylar_prf.models.gaussian import _expand_gaussian_args
+from popylar_prf.models.gaussian import predict_gaussian_response
+from popylar_prf.stimulus import GridDimensionsError
+
+
+class TestCheckGaussianArgs:
+    """Tests for _check_gaussian_args function."""
+
+    def test_grid_dimensions_error(self):
+        """Test that GridDimensionsError is raised."""
+        grid = np.ones((4, 5, 1))  # len(shape[:-1]) = 2, shape[-1] = 1
+        mu = np.ones((3, 1))
+        sigma = np.ones((3, 1))
+        with pytest.raises(GridDimensionsError):
+            _check_gaussian_args(grid, mu, sigma)
+
+    def test_grid_mu_dimensions_error(self):
+        """Test that GridMuDimensionsError is raised."""
+        grid = np.ones((4, 5, 2))
+        mu = np.ones((3, 3))  # mu.shape[-1] = 3, grid.shape[-1] = 2
+        sigma = np.ones((3, 1))
+        with pytest.raises(GridMuDimensionsError):
+            _check_gaussian_args(grid, mu, sigma)
+
+    def test_parameter_size_error(self):
+        """Test that ParameterSizeError is raised."""
+        grid = np.ones((4, 5, 2))
+        mu = np.ones((2, 2))
+        sigma = np.ones((3, 1))  # Mismatch in first axis
+        with pytest.raises(ParameterBatchDimensionError):
+            _check_gaussian_args(grid, mu, sigma)
+
+    def test_parameter_shape_error(self):
+        """Test that ParameterShapeError is raised."""
+        grid = np.ones((4, 1))
+        mu = np.ones(1)  # Less than two dimensions
+        sigma = np.ones((3, 1))
+        with pytest.raises(ParameterShapeError):
+            _check_gaussian_args(grid, mu, sigma)
+
+        mu = np.ones((3, 1))
+        sigma = np.ones(3)  # Less than two dimensions
+
+        with pytest.raises(ParameterShapeError):
+            _check_gaussian_args(grid, mu, sigma)
+
+
+class TestSetup:
+    """Setup parameters and objects for testing."""
+
+    width: int = 5
+    height: int = 4
+    depth: int = 3
+
+    @pytest.fixture
+    def grid_1d(self):
+        """1D stimulus grid."""
+        return np.expand_dims(np.linspace(-2, 2, num=self.height), axis=1)  # (height, 1)
+
+    @pytest.fixture
+    def grid_2d(self):
+        """2D stimulus grid."""
+        y = np.linspace(-2, 2, num=self.height)
+        x = np.linspace(-2, 2, num=self.width)
+        xv, yv = np.meshgrid(x, y)
+        return np.stack((xv, yv), axis=-1)  # (height, width, 2)
+
+    @pytest.fixture
+    def grid_3d(self):
+        """3D stimulus grid."""
+        y = np.linspace(-2, 2, num=self.height)
+        x = np.linspace(-2, 2, num=self.width)
+        z = np.linspace(-2, 2, num=self.depth)
+        xv, yv, zv = np.meshgrid(x, y, z)
+        return np.stack((xv, yv, zv), axis=-1)  # (height, width, depth, 3)
+
+    @pytest.fixture
+    def mu_1d(self):
+        """1D Gaussian mu parameters."""
+        return np.expand_dims(np.array([0.0, 1.0, 2.0]), axis=1)  # (num_voxels, 1)
+
+    @pytest.fixture
+    def mu_2d(self):
+        """2D Gaussian mu parameters."""
+        return np.array(
+            [  # (num_voxels, 2)
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [0.0, 0.0],
+            ],
+        )
+
+    @pytest.fixture
+    def mu_3d(self):
+        """3D Gaussian mu parameters."""
+        return np.array(
+            [  # (num_voxels, 3)
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0],
+            ],
+        )
+
+    @pytest.fixture
+    def sigma(self):
+        """Gaussian sigma parameters."""
+        return np.expand_dims(np.array([1.0, 1.5, 2.0]), axis=1)  # (num_voxels, 1)
+
+
+class TestExpandGaussianArgs(TestSetup):
+    """Tests for _expand_gaussian_args function."""
+
+    @staticmethod
+    def _check_shapes(grid: np.ndarray, mu: np.ndarray, sigma: np.ndarray) -> None:
+        assert len(grid.shape) == len(mu.shape)
+        assert len(mu.shape) - 1 == len(sigma.shape)
+        assert grid.shape[-1] == mu.shape[-1]
+
+    def test_expand_gaussian_args_1d(self, grid_1d: np.ndarray, mu_1d: np.ndarray, sigma: np.ndarray):
+        """Test that 1D args are correctly expanded."""
+        grid, mu, sigma = _expand_gaussian_args(grid_1d, mu_1d, sigma)
+
+        self._check_shapes(grid, mu, sigma)
+
+    def test_expand_gaussian_args_2d(self, grid_2d: np.ndarray, mu_2d: np.ndarray, sigma: np.ndarray):
+        """Test that 2D args are correctly expanded."""
+        grid, mu, sigma = _expand_gaussian_args(grid_2d, mu_2d, sigma)
+
+        self._check_shapes(grid, mu, sigma)
+
+    def test_expand_gaussian_args_3d(self, grid_3d: np.ndarray, mu_3d: np.ndarray, sigma: np.ndarray):
+        """Test that 3D args are correctly expanded."""
+        grid, mu, sigma = _expand_gaussian_args(grid_3d, mu_3d, sigma)
+
+        self._check_shapes(grid, mu, sigma)
+
+
+class TestPredictGaussianResponse(TestSetup):
+    """Tests for predict_gaussian_response function."""
+
+    def test_predict_gaussian_response_1d(self, grid_1d: np.ndarray, mu_1d: np.ndarray, sigma: np.ndarray):
+        """Test that 1D response prediction returns correct shape."""
+        preds = predict_gaussian_response(grid_1d, mu_1d, sigma)
+
+        assert preds.shape == (3, self.height)
+
+    def test_predict_gaussian_response_2d(self, grid_2d: np.ndarray, mu_2d: np.ndarray, sigma: np.ndarray):
+        """Test that 2D response prediction returns correct shape."""
+        preds = predict_gaussian_response(grid_2d, mu_2d, sigma)
+
+        assert preds.shape == (3, self.height, self.width)
+
+    def test_predict_gaussian_response_3d(self, grid_3d: np.ndarray, mu_3d: np.ndarray, sigma: np.ndarray):
+        """Test that 3D response prediction returns correct shape."""
+        preds = predict_gaussian_response(grid_3d, mu_3d, sigma)
+
+        assert preds.shape == (3, self.height, self.width, self.depth)


### PR DESCRIPTION
Closes #1 
Closes #2 
Closes #7 

Adds:

- A model base class
- A response model base class
- A generic function for Gaussian pRF responses
- A 2D Gaussian Response Model class
- Several exceptions
- A workflow for testing on all three backends
- A worfklow for type checking

I chose to implement the Gaussian response function in an independent function that works for any number of dimensions (tested for 1, 2, and 3 dimensions). That way the response model classes only become a light wrapper around the function.

In the tests, I made heavy use of inheritance and fixtures so that we don't need to repeat creating objects and tests.

Also, numpy is apparently not a valid backend, but is only used for some operations in `keras.ops`.